### PR TITLE
Changes the URL for google analytics ga.js

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Ga.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Ga.php
@@ -29,7 +29,7 @@
 class Fooman_GoogleAnalyticsPlus_Block_Ga extends Fooman_GoogleAnalyticsPlus_Block_Common_Abstract
 {
 
-    const URL_GA_STANDARD = 'http://google-analytics.com/ga.js';
+    const URL_GA_STANDARD = 'http://www.google-analytics.com/ga.js';
     const URL_GA_STANDARD_SECURE = 'https://ssl.google-analytics.com/ga.js';
     const URL_DOUBLECLICK = 'http://stats.g.doubleclick.net/dc.js';
     const URL_DOUBLECLICK_SECURE = 'https://stats.g.doubleclick.net/dc.js';


### PR DESCRIPTION
The Google Chrome debugger for Analytics does not pick up the ga.js if it is served without the www subdomain. This change fixes this as it is more practical for us to change the url rather than have Google change their extension.
