### PR TITLE
Make merchants feed product id configurable for remarketing.

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Remarketing.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Remarketing.php
@@ -117,14 +117,14 @@ class Fooman_GoogleAnalyticsPlus_Block_Remarketing extends Fooman_GoogleAnalytic
     {
         switch ($this->getPageType()) {
             case self::GA_PAGETYPE_PRODUCT:
-                $products[] = Mage::registry('current_product')->getId();
+                $products[] = $this->getConfiguredFeedId(Mage::registry('current_product'));
                 return $this->getArrayReturnValue($products, '');
                 break;
             case self::GA_PAGETYPE_CART:
                 $quote = Mage::getSingleton('checkout/session')->getQuote();
                 if ($quote) {
                     foreach ($quote->getAllItems() as $item) {
-                        $products[] = $item->getProductId();
+                        $products[] = $this->getConfiguredFeedId($item);
                     }
                 }
                 return $this->getArrayReturnValue($products, '', true);
@@ -132,13 +132,27 @@ class Fooman_GoogleAnalyticsPlus_Block_Remarketing extends Fooman_GoogleAnalytic
             case self::GA_PAGETYPE_PURCHASE:
                 if ($this->_getOrder()) {
                     foreach ($this->_getOrder()->getAllItems() as $item) {
-                        $products[] = $item->getProductId();
+                        $products[] = $this->getConfiguredFeedId($item);
                     }
                 }
                 return $this->getArrayReturnValue($products, '', true);
                 break;
         }
         return false;
+    }
+    
+    /**
+     * @param Mage_Catalog_Model_Product $product
+     * @return string|integer
+     */
+    public function getConfiguredFeedId ($product) {
+        $idAttr = Mage::getStoreConfig('google/analyticsplus_dynremarketing/feed_product_id');
+        $id = $product->getData($idAttr);
+        // quote if id is not numeric
+        if (!ctype_digit($id)) {
+            $id = "'$id'";
+        }
+        return $id;
     }
 
     /**

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Model/Source/Productattribute.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Model/Source/Productattribute.php
@@ -21,6 +21,10 @@ class Fooman_GoogleAnalyticsPlus_Model_Source_Productattribute
             'value' => '',
             'label' => ''
         );
+        $options[] = array(
+                'value' => 'entity_id',
+                'label' => 'Entity Id'
+        );
         foreach ($collection as $attribute) {
             $options[] = array(
                 'value' => $attribute->getAttributeCode(),

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
@@ -269,6 +269,17 @@
                             <show_in_store>1</show_in_store>
                             <depends><enabled>1</enabled></depends>
                         </conversionlabel>
+                        <feed_product_id translate="label">
+                            <label>Product ID in Merchants Feed</label>
+                            <comment><![CDATA[Must match the attribute you are using as Product ID in Google Merchants Feed.]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>googleanalyticsplus/source_productattribute</source_model>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
+                        </feed_product_id>
                     </fields>
                 </analyticsplus_dynremarketing>
             </groups>


### PR DESCRIPTION
Just a quick hack to enable configuration of the product id attribute used in Google Merchants Feed.
In our case we are using the SKU instead of Entity Id.
