### PR TITLE
Fix JS error for users that don't have Ajax included

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Ga.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Ga.php
@@ -309,7 +309,7 @@ class Fooman_GoogleAnalyticsPlus_Block_Ga extends Fooman_GoogleAnalyticsPlus_Blo
 
         return "
 
-            if(Ajax.Responders){
+            if(typeof Ajax !== \"undefined\" && Ajax.Responders){
                 Ajax.Responders.register({
                   onComplete: function(transport){
                     if(!transport.url.include('progress') && !transport.url.include('getAdditional')){


### PR DESCRIPTION
Some users only include prototype on certain pages, this conditional will always error unless it's included.
