### PR TITLE
Added ability to add custom checkout success page handles

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Common/Abstract.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Common/Abstract.php
@@ -2,6 +2,8 @@
 
 class Fooman_GoogleAnalyticsPlus_Block_Common_Abstract extends Mage_Core_Block_Template
 {
+    const XML_PATH_SUCCESS_PAGE_BLOCK_HANDLES = 'google/analyticsplus_abstract/success_page_handles';
+    
     /**
      * where cookie opt in is present and not yet accepted do not track
      *
@@ -26,8 +28,13 @@ class Fooman_GoogleAnalyticsPlus_Block_Common_Abstract extends Mage_Core_Block_T
     public function isSuccessPage()
     {
         $handles = $this->getLayout()->getUpdate()->getHandles();
-        return in_array('checkout_onepage_success', $handles)
-        || in_array('checkout_multishipping_success', $handles);
+        foreach (array_keys(Mage::getStoreConfig(self::XML_PATH_SUCCESS_PAGE_BLOCK_HANDLES)) as $handle) {
+            if (in_array($handle, $handles)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Ga.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Ga.php
@@ -139,11 +139,8 @@ class Fooman_GoogleAnalyticsPlus_Block_Ga extends Fooman_GoogleAnalyticsPlus_Blo
      */
     public function isSuccessPage()
     {
-        $handles = $this->getLayout()->getUpdate()->getHandles();
         $orderIds = $this->getOrderIds();
-        return in_array('checkout_onepage_success', $handles)
-        || in_array('checkout_multishipping_success', $handles)
-        || (!empty($orderIds) && is_array($orderIds));
+        return parent::isSuccessPage() || (!empty($orderIds) && is_array($orderIds));
     }
 
 

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/etc/config.xml
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/etc/config.xml
@@ -41,6 +41,12 @@
     </frontend>
     <default>
         <google>
+            <analyticsplus_abstract>
+                <success_page_handles>
+                    <checkout_multishipping_success/>
+                    <checkout_onepage_success/>
+                </success_page_handles>
+            </analyticsplus_abstract>
             <analyticsplus_classic>
                 <accountnumber2/>
                 <domainname2/>


### PR DESCRIPTION
Moving the handles into config.xml allows for integrators to specify/add their own custom success page handles via their own config.xml instead of modifying the module.
