### PR TITLE
Make cookie restrict mode configurable, support google opt out cookie.

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Common/Abstract.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Common/Abstract.php
@@ -13,7 +13,7 @@ class Fooman_GoogleAnalyticsPlus_Block_Common_Abstract extends Mage_Core_Block_T
     {
         $coreHelperDir = Mage::getConfig()->getModuleDir('', 'Mage_Core') . DS . 'Helper' . DS;
         if (file_exists($coreHelperDir . 'Cookie.php')) {
-            if (Mage::helper('core/cookie')->isUserNotAllowSaveCookie()) {
+            if (Mage::getStoreConfigFlag('google/analyticsplus/respectcookierestrict') && Mage::helper('core/cookie')->isUserNotAllowSaveCookie()) {
                 return false;
             }
         }

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/OptOut.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/OptOut.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * @category    Mage
+ * @package     Mage_GoogleAnalytics
+ * @copyright   Copyright (c) 2009 Irubin Consulting Inc. DBA Varien (http://www.varien.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Google Analytics block
+ *
+ * @category   Fooman
+ * @package    Fooman_GoogleAnalyticsPlus
+ * @author     Magento Core Team <core@magentocommerce.com>
+ * @author     Erik Dannenberg <erik.dannenberg@bbe-consulting.de>
+ */
+class Fooman_GoogleAnalyticsPlus_Block_OptOut extends Fooman_GoogleAnalyticsPlus_Block_Common_Abstract
+{
+
+    protected function _construct()
+    {
+        parent::_construct();
+        $this->setTemplate('fooman/googleanalyticsplus/optout.phtml');
+    }
+
+    /**
+     * should we include opt out code
+     *
+     * @return bool
+     */
+    public function shouldIncludeOptOut()
+    {
+        return Mage::getStoreConfigFlag('google/analyticsplus/enableoptoutcookie');
+    }
+
+    /**
+     * get Google Analytics account id
+     *
+     * @return mixed
+     */
+    public function getAccountId()
+    {
+        if ($id = Mage::getStoreConfig(Mage_GoogleAnalytics_Helper_Data::XML_PATH_ACCOUNT)) {
+            return $id;
+        }
+        if ($id = Mage::getStoreConfig('google/analyticsplus_universal/accountnumber')) {
+            return $id;
+        }
+    }
+
+}

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
@@ -17,6 +17,38 @@
                     ]]>
                     </comment>
                     <fields>
+                        <respectcookierestrict translate='label'>
+                            <label>Respect cookie restrict mode</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>500</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <comment><![CDATA[<br />
+                            <div class="box">
+                            <p>Do not track users if <a href="http://www.magentocommerce.com/knowledge-base/entry/using-cookies-with-expressed-consent">cookie restrict mode</a> is enabled
+                            and the user did not accept the store cookies. Note: Using a FPC will require hole punching for the tracking code.
+                            </p>
+                            </div>
+                            ]]></comment>
+                        </respectcookierestrict>
+                        <enableoptoutcookie translate='label'>
+                            <label>Enable opt out cookie</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>510</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <comment><![CDATA[<br />
+                            <div class="box">
+                            <p>Add support for <a href="https://developers.google.com/analytics/devguides/collection/gajs/?hl=de#disable">google opt out cookie</a>.
+                            Add a link like "&lt;a href=&quot;javascript:gaOptout()&quot;&gt;Click here to opt-out of Google Analytics&lt;/a&gt;" to pages of your choice.
+                            </p>
+                            </div>
+                            ]]></comment>
+                        </enableoptoutcookie>
                         <convertcurrencyenabled translate='label'>
                             <label>Convert Currency</label>
                             <frontend_type>select</frontend_type>

--- a/app/design/frontend/base/default/layout/googleanalyticsplus.xml
+++ b/app/design/frontend/base/default/layout/googleanalyticsplus.xml
@@ -8,6 +8,8 @@
             </action>
         </reference>
         <reference name="before_head_end">
+            <block type="googleanalyticsplus/optOut" name="googleanalyticsplus_optout"
+                   as="googleanalyticsplus_optOut"/>
             <block type="googleanalyticsplus/ga" name="google_analytics" as="google_analytics"/>
             <block type="googleanalyticsplus/tagManager" name="googleanalyticsplus_tagmanager"
                    as="googleanalyticsplus_tagmanager"/>

--- a/app/design/frontend/base/default/template/fooman/googleanalyticsplus/optout.phtml
+++ b/app/design/frontend/base/default/template/fooman/googleanalyticsplus/optout.phtml
@@ -1,0 +1,17 @@
+<?php if ($this->shouldIncludeOptOut()): ?>
+    <!-- Google Analytics OptOut -->
+    <script>
+    var gaProperty = '<?php echo $this->getAccountId(); ?>';
+    
+    var disableStr = 'ga-disable-' + gaProperty;
+    if (document.cookie.indexOf(disableStr + '=true') > -1) {
+      window[disableStr] = true;
+    }
+    
+    function gaOptout() {
+      document.cookie = disableStr + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
+      window[disableStr] = true;
+    }
+    </script>
+    <!-- End Google Analytics OptOut -->
+<?php endif; ?>


### PR DESCRIPTION
This PR adds 2 options to the backend:

*  Respect Cookie Restrict Mode

Currently when cookie restrict mode is enabled in Magento and the User did not accept the cookies the tracking code will not render. This creates problems when using a FPC, unless you punch another hole for the tracking. This new option enables users to still render the tracking code even if the user did not accept the store cookies and use option 2 instead:

* Support Google Opt Out Cookie

As an alternative this options provides support for using a Google Opt Out cookie. Requires placing a link to the opt out function in your relevant CMS pages (privacy policy etc). Snippet is provided in the comment section.

Disclaimer: We are running this patch in production, it might need some further adjustments when using multiple analytics accounts though.
