### PR TITLE
Added 2 option to allow shipping and tax to be excluded from conversion total revenue in UA

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Common/Abstract.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Common/Abstract.php
@@ -208,4 +208,14 @@ class Fooman_GoogleAnalyticsPlus_Block_Common_Abstract extends Mage_Core_Block_T
     {
         return Mage::getStoreConfigFlag('google/analyticsplus_tagmanager/enabled');
     }
+    
+    public function excludeShipping()
+    {
+        return Mage::getStoreConfigFlag('google/analyticsplus_universal/exclude_shipping');
+    }
+    
+    public function excludeTax()
+    {
+        return Mage::getStoreConfigFlag('google/analyticsplus_universal/exclude_tax');
+    }
 }

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Common/Abstract.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Common/Abstract.php
@@ -209,13 +209,5 @@ class Fooman_GoogleAnalyticsPlus_Block_Common_Abstract extends Mage_Core_Block_T
         return Mage::getStoreConfigFlag('google/analyticsplus_tagmanager/enabled');
     }
     
-    public function excludeShipping()
-    {
-        return Mage::getStoreConfigFlag('google/analyticsplus_universal/exclude_shipping');
-    }
-    
-    public function excludeTax()
-    {
-        return Mage::getStoreConfigFlag('google/analyticsplus_universal/exclude_tax');
-    }
+  
 }

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Universal.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Universal.php
@@ -148,5 +148,16 @@ class Fooman_GoogleAnalyticsPlus_Block_Universal extends Fooman_GoogleAnalyticsP
 
         return self::URL_ANALYTICS;
     }
+    // Get the exclude shipping settings
+    public function excludeShipping()
+    {
+        return Mage::getStoreConfigFlag('google/analyticsplus_universal/exclude_shipping');
+    }
+    
+    // Get the exclude Tax Settings....
+    public function excludeTax()
+    {
+        return Mage::getStoreConfigFlag('google/analyticsplus_universal/exclude_tax');
+    }
 
 }

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
@@ -267,7 +267,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </enabled>
+                        </exclude_shipping>
                         <exclude_tax translate='label'>
                             <label>Exclude Tax from Conversion Total</label>
                             <frontend_type>select</frontend_type>
@@ -276,7 +276,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </enabled>
+                        </exclude_tax>
                         <debug translate="label">
                             <label>Debug</label>
                             <frontend_type>select</frontend_type>

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
@@ -259,6 +259,24 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </userid_tracking>
+                        <exclude_shipping translate='label'>
+                            <label>Exclude Shipping from Conversion Total</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>502</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </enabled>
+                        <exclude_tax translate='label'>
+                            <label>Exclude Tax from Conversion Total</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>504</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </enabled>
                         <debug translate="label">
                             <label>Debug</label>
                             <frontend_type>select</frontend_type>

--- a/app/design/frontend/base/default/template/fooman/googleanalyticsplus/universal.phtml
+++ b/app/design/frontend/base/default/template/fooman/googleanalyticsplus/universal.phtml
@@ -39,12 +39,19 @@
             ga('<?php echo Fooman_GoogleAnalyticsPlus_Block_Universal::TRACKER_TWO_NAME?>.require', 'ecommerce', 'ecommerce.js');
         <?php endif;?>
 
-            <?php $transactionDetails = "{
-            'id': '".$this->jsQuoteEscape($order->getIncrementId()) ."',
+            <?php 
+            $shipping = Mage::helper('googleanalyticsplus')->convert($order, 'shipping_amount');
+            $tax = Mage::helper('googleanalyticsplus')->convert($order, 'tax_amount');
+            $revenue =  Mage::helper('googleanalyticsplus')->convert($order, 'grand_total');
+            $revenue -= ($this->excludeShipping())? $shipping : 0);
+            $revenue -= ($this->excludeTax())? $tax : 0);
+            
+            $transactionDetails = "{
+            'id': '". $this->jsQuoteEscape($order->getIncrementId()) ."',
             'affiliation': '". $this->jsQuoteEscape(Mage::app()->getStore()->getName()) ."',
-            'revenue': '". Mage::helper('googleanalyticsplus')->convert($order, 'grand_total') ."',
-            'shipping': '". Mage::helper('googleanalyticsplus')->convert($order, 'shipping_amount') ."',
-            'tax': '". Mage::helper('googleanalyticsplus')->convert($order, 'tax_amount') ."',
+            'revenue': '". $revenue ."',
+            'shipping': '". $shipping ."',
+            'tax': '". $tax ."',
             'currency': '". Mage::helper('googleanalyticsplus')->getTrackingCurrency($order) ."'
             }";
             ?>

--- a/app/design/frontend/base/default/template/fooman/googleanalyticsplus/universal.phtml
+++ b/app/design/frontend/base/default/template/fooman/googleanalyticsplus/universal.phtml
@@ -43,8 +43,8 @@
             $shipping = Mage::helper('googleanalyticsplus')->convert($order, 'shipping_amount');
             $tax = Mage::helper('googleanalyticsplus')->convert($order, 'tax_amount');
             $revenue =  Mage::helper('googleanalyticsplus')->convert($order, 'grand_total');
-            $revenue -= ($this->excludeShipping())? $shipping : 0);
-            $revenue -= ($this->excludeTax())? $tax : 0);
+            $revenue -= (($this->excludeShipping())? $shipping : 0);
+            $revenue -= (($this->excludeTax())? $tax : 0);
             
             $transactionDetails = "{
             'id': '". $this->jsQuoteEscape($order->getIncrementId()) ."',


### PR DESCRIPTION
At our business we had a requirement to exclude shipping and tax from the conversion total revenue in Google Universal Analytics.

This change add 2 options to the Google Universal Analytics section to allow tax and revenue to be excluded from the total revenue.

It's a simple change affecting only 3 files - please feel free to include back into the master if you think its a useful addition.