### PR TITLE
Hide ecomm_totalvalue If Not Applicable

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Remarketing.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Remarketing.php
@@ -132,7 +132,7 @@ class Fooman_GoogleAnalyticsPlus_Block_Remarketing extends Fooman_GoogleAnalytic
                 }
                 return $this->getArrayReturnValue($values, '0.00');
         }
-        return "''";
+        return false;
     }
 
     /**


### PR DESCRIPTION
With the current implementation, the tag assistant shows the error "Number field should not be quoted: 'ecomm_totalvalue'" on pages where the value is empty. The reason is that it is rendered with an empty value `''` and not hidden. This pull request ensures that the value is not rendered at all on pages where it is not applicable.