### PR TITLE
Check if the dataLayer variable exists before trying to use it

### DIFF
--- a/app/design/frontend/base/default/template/fooman/googleanalyticsplus/ajax-tracking.phtml
+++ b/app/design/frontend/base/default/template/fooman/googleanalyticsplus/ajax-tracking.phtml
@@ -20,7 +20,7 @@
             if (this.altUniversal) {
                 ga('<?php echo Fooman_GoogleAnalyticsPlus_Block_Universal::TRACKER_TWO_NAME?>.send', 'pageview', urlToTrack);
             }
-            if (this.useDataLayer) {
+            if (this.useDataLayer && typeof dataLayer != 'undefined') {
                 dataLayer.push({'event': section});
             }
         }


### PR DESCRIPTION
When you enable Google Tag Manager and forget to enter the container snippet, the checkout stops working all together, because the dataLayer variable isn't being defined and all other Magento javascript functionality stops working.