### PR TITLE
Add support for the ‘forceSSL’ option

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Universal.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/Universal.php
@@ -45,6 +45,14 @@ class Fooman_GoogleAnalyticsPlus_Block_Universal extends Fooman_GoogleAnalyticsP
     }
 
     /**
+     * @return bool
+     */
+    public function getUniversalForceSSL()
+    {
+        return Mage::getStoreConfigFlag('google/analyticsplus_universal/force_ssl');
+    }
+
+    /**
      * Build any params that is passed on create of analytics object
      *
      * @param bool $createTrackerTwo

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
@@ -164,6 +164,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </anonymise>
+                        <force_ssl translate="label">
+                            <label>Force HTTPS</label>
+                            <comment><![CDATA[See <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#forceSSL" target="_blank">Google Documentation</a> for details]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>200</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </force_ssl>
                         <domainname translate="label">
                             <label>Cookie Domain Name</label>
                             <comment><![CDATA[Leave empty for standard setups <br/><a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#cookieDomain" target="_blank">Google Documentation</a>]]></comment>

--- a/app/design/frontend/base/default/template/fooman/googleanalyticsplus/universal.phtml
+++ b/app/design/frontend/base/default/template/fooman/googleanalyticsplus/universal.phtml
@@ -19,6 +19,12 @@
                 ga('<?php echo Fooman_GoogleAnalyticsPlus_Block_Universal::TRACKER_TWO_NAME?>.set', 'anonymizeIp', true);
             <?php endif;?>
         <?php endif;?>
+        <?php if($this->getUniversalForceSSL()):?>
+            ga('set', 'forceSSL', true);
+            <?php if ($altUniversal):?>
+                ga('<?php echo Fooman_GoogleAnalyticsPlus_Block_Universal::TRACKER_TWO_NAME?>.set', 'forceSSL', true);
+            <?php endif;?>
+        <?php endif;?>
         <?php if($this->getUniversalDisplayAdvertising()):?>
             ga('require', 'displayfeatures'<?php if($this->getUniversalDisplayAdvertisingCookieName()):?>, undefined, { cookieName: '<?php echo $this->getUniversalDisplayAdvertisingCookieName(); ?>' }<?php endif; ?>);
             <?php if ($altUniversal):?>


### PR DESCRIPTION
This PR adds an option to the backend for toggling the 'forceSSL' GA option