### PR TITLE
Google optout cookie support

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/OptOut.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/OptOut.php
@@ -4,7 +4,7 @@
  *
  * @package   Fooman_GoogleAnalyticsPlus
  * @author    Kristof Ringleff <kristof@fooman.co.nz>
- * @author    Niklas Wolf <wolf@mothership.de>
+ * @author    Niklas Wolf <wolf[ät]mothership.de>
  * @copyright Copyright (c) 2010 Fooman Limited (http://www.fooman.co.nz)
  *
  * For the full copyright and license information, please view the LICENSE

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/OptOut.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/OptOut.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Fooman GoogleAnalyticsPlus
+ *
+ * @package   Fooman_GoogleAnalyticsPlus
+ * @author    Kristof Ringleff <kristof@fooman.co.nz>
+ * @author    Niklas Wolf <wolf@mothership.de>
+ * @copyright Copyright (c) 2010 Fooman Limited (http://www.fooman.co.nz)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Fooman_GoogleAnalyticsPlus_Block_OptOut extends Fooman_GoogleAnalyticsPlus_Block_Common_Abstract
+{
+    protected function _construct()
+    {
+        parent::_construct();
+        $this->setTemplate('fooman/googleanalyticsplus/optout.phtml');
+    }
+
+    /**
+     * should opt out code be included
+     * @return bool
+     */
+    public function shouldIncludeOptOut()
+    {
+        return Mage::getStoreConfigFlag('google/analyticsplus/enableoptoutcookie');
+
+    }
+}

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
@@ -34,6 +34,22 @@
                     ]]>
                     </comment>
                     <fields>
+                        <enableoptoutcookie translate='label'>
+                            <label>Enable opt out cookie</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>510</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <comment><![CDATA[<br />
+                            <div class="box">
+                            <p>Add support for <a href="https://developers.google.com/analytics/devguides/collection/gajs/?hl=de#disable">google opt out cookie</a>.
+                            Add a link like "&lt;a href=&quot;javascript:gaOptout()&quot;&gt;Click here to opt-out of Google Analytics&lt;/a&gt;" to pages of your choice.
+                            </p>
+                            </div>
+                            ]]></comment>
+                        </enableoptoutcookie>
                         <convertcurrencyenabled translate='label'>
                             <label>Convert Currency</label>
                             <frontend_type>select</frontend_type>

--- a/app/design/frontend/base/default/layout/googleanalyticsplus.xml
+++ b/app/design/frontend/base/default/layout/googleanalyticsplus.xml
@@ -8,6 +8,8 @@
             </action>
         </reference>
         <reference name="before_head_end">
+            <block type="googleanalyticsplus/optOut" name="googleanalyticsplus_optout"
+                   as="googleanalyticsplus_optOut"/>
             <block type="googleanalyticsplus/universal" name="googleanalyticsplus_universal"
                    as="googleanalyticsplus_universal"/>
             <block type="googleanalyticsplus/tagManagerHead" name="googleanalyticsplus_tagmanager_head"

--- a/app/design/frontend/base/default/template/fooman/googleanalyticsplus/optout.phtml
+++ b/app/design/frontend/base/default/template/fooman/googleanalyticsplus/optout.phtml
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @var $this Fooman_GoogleAnalyticsPlus_Block_OptOut
+ */
+$altUniversal = $this->getAlternativeUniversalAccount();
+?>
+<?php if ($this->shouldIncludeOptOut()): ?>
+    <!-- Google Analytics OptOut -->
+    <script>
+        var gaProperty = '<?php echo $this->getUniversalAccount(); ?>';
+        <?php if ($altUniversal): ?>
+        var altGaProperty = '<?php echo $altUniversal; ?>';
+        <?php endif; ?>
+
+        var disableStr = 'ga-disable-' + gaProperty;
+        if (document.cookie.indexOf(disableStr + '=true') > -1) {
+            window[disableStr] = true;
+        }
+        <?php if($altUniversal): ?>
+        var altDisableStr = 'ga-disable-' + altGaProperty;
+        if (document.cookie.indexOf(altDisableStr + '=true') > -1) {
+            window[altDisableStr] = true;
+        }
+        <?php endif; ?>
+        function gaOptout() {
+            document.cookie = disableStr + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
+            window[disableStr] = true;
+            <?php if($altUniversal): ?>
+            document.cookie = altDisableStr + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
+            window[altDisableStr] = true;
+            <?php endif; ?>
+        }
+    </script>
+    <!-- End Google Analytics OptOut -->
+<?php endif; ?>


### PR DESCRIPTION
Hi @fooman,
here is the seperate PR you requested in PR https://github.com/fooman/googleanalyticsplus/pull/49. 
It adds only the Optout-part and also takes care of the alternative account.

Its based on the code of @edannenberg, but I also did some slight modifications.