### PR TITLE
remove dublicate script tags in tagmanager template

### DIFF
--- a/app/code/community/Fooman/GoogleAnalyticsPlus/Block/TagManager.php
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/Block/TagManager.php
@@ -21,27 +21,17 @@ class Fooman_GoogleAnalyticsPlus_Block_TagManager extends Fooman_GoogleAnalytics
     }
 
     /**
-     * should we include the tag manager snippet
+     * should we include the tag manager
      *
      * @return bool
      */
     public function shouldInclude()
     {
         if (parent::shouldInclude()) {
-            return $this->isTagManagerEnabled() && (bool)$this->getTagManagerSnippet() && (bool)$this->getTagManagerId();
+            return $this->isTagManagerEnabled() && (bool)$this->getTagManagerId();
         } else {
             return false;
         }
-    }
-
-    /**
-     * get tag manager snippet from settings
-     *
-     * @return string
-     */
-    public function getTagManagerSnippet()
-    {
-        return Mage::getStoreConfig('google/analyticsplus_tagmanager/snippet');
     }
 
 

--- a/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
+++ b/app/code/community/Fooman/GoogleAnalyticsPlus/etc/system.xml
@@ -317,15 +317,6 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </tagmanagerid>
-                        <snippet translate='label'>
-                            <label>Container Snippet</label>
-                            <frontend_type>textarea</frontend_type>
-                            <sort_order>20</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <depends><enabled>1</enabled></depends>
-                        </snippet>
                     </fields>
                 </analyticsplus_tagmanager>
                 <analyticsplus_dynremarketing translate="label">

--- a/app/design/frontend/base/default/template/fooman/googleanalyticsplus/tagmanager_head.phtml
+++ b/app/design/frontend/base/default/template/fooman/googleanalyticsplus/tagmanager_head.phtml
@@ -1,6 +1,5 @@
 <?php /* @var $this Fooman_GoogleAnalyticsPlus_Block_TagManagerHead */ ?>
 <?php if ($this->shouldInclude()): ?>
-    <script>
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -8,5 +7,4 @@
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','<?php echo $this->getTagManagerId();?>');</script>
         <!-- End Google Tag Manager -->
-    </script>
 <?php endif; ?>


### PR DESCRIPTION
Tagmanager is not working now, we need to remove the dublicated script tags in tagmanger template file 