### PR TITLE
fixed check if prodId is set, fixes #122

### DIFF
--- a/app/design/frontend/base/default/template/fooman/googleanalyticsplus/remarketing.phtml
+++ b/app/design/frontend/base/default/template/fooman/googleanalyticsplus/remarketing.phtml
@@ -10,7 +10,7 @@
 <script>
     /* <![CDATA[ */
     var google_tag_params = {
-        <?php if($prodId !== ''):?>
+        <?php if($prodId !== '' && $prodId !== false):?>
         ecomm_prodid: <?php echo $prodId ?>,
         <?php endif;?>
         ecomm_pagetype: '<?php echo $pageType ?>',


### PR DESCRIPTION
`Fooman_GoogleAnalyticsPlus_Block_Remarketing::getProdId` returns `false` on e.g. the catalogsearch result page.